### PR TITLE
Add web app capability on iOS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,8 @@
     <meta name="description" content="Directly edit org-mode files online. Optimized for mobile. Syncs with Dropbox and Google Drive.">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="theme-color" content="#5E348C">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/org-web.png">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.1/css/all.css" integrity="sha384-O8whS3fhG2OnA5Kas0Y9l3cfpmYjapjI0E4theH4iuMD+pLhbf6JI0jIMfYcK3yZ" crossorigin="anonymous">


### PR DESCRIPTION
This removes the browser chrome when adding the app on the home screen on iOS, which makes it look more like a native app. But more importantly gives you more screen space to edit your files! 😃