### PR TITLE
Set default keybindings as in Emacs

### DIFF
--- a/src/lib/keybindings.js
+++ b/src/lib/keybindings.js
@@ -1,18 +1,18 @@
 const DEFAULT_BINDINGS = [
-  ['Select next header', 'selectNextVisibleHeader', 'ctrl+n'],
-  ['Select previous header', 'selectPreviousVisibleHeader', 'ctrl+p'],
+  ['Select next header', 'selectNextVisibleHeader', 'ctrl+down'],
+  ['Select previous header', 'selectPreviousVisibleHeader', 'ctrl+up'],
   ['Toggle header opened', 'toggleHeaderOpened', 'tab'],
-  ['Advance todo state', 'advanceTodo', 'ctrl+t'],
+  ['Advance todo state', 'advanceTodo', 'alt+t'],
   ['Edit title', 'editTitle', 'ctrl+h'],
   ['Edit description', 'editDescription', 'ctrl+d'],
-  ['Exit edit mode', 'exitEditMode', 'command+enter'],
+  ['Exit edit mode', 'exitEditMode', 'alt+enter'],
   ['Add header', 'addHeader', 'ctrl+enter'],
   ['Remove header', 'removeHeader', 'backspace'],
-  ['Move header up', 'moveHeaderUp', 'ctrl+command+p'],
-  ['Move header down', 'moveHeaderDown', 'ctrl+command+n'],
-  ['Move header left', 'moveHeaderLeft', 'ctrl+command+b'],
-  ['Move header right', 'moveHeaderRight', 'ctrl+command+f'],
-  ['Undo', 'undo', 'ctrl+shift+-'],
+  ['Move header up', 'moveHeaderUp', 'alt+up'],
+  ['Move header down', 'moveHeaderDown', 'alt+down'],
+  ['Move header left', 'moveHeaderLeft', 'alt+shift+left'],
+  ['Move header right', 'moveHeaderRight', 'alt+shift+right'],
+  ['Undo', 'undo', 'ctrl+/'],
 ];
 
 export const calculateNamedKeybindings = customKeybindings =>


### PR DESCRIPTION
I noticed that some keybindings have a different standard shortcut than in Emacs. For consistency (and to re-use or train muscle memory), imo it's good to have the defaults set the same as in Emacs. Some keybindings are even shorter than what org-web proposed before as default (`ctrl+shift+-` to undo unstead of `ctrl+/` or moving headers around).

Some of these changes were done because the keybindings before didn't work as they were caught by the system. For example `ctrl+n`, `ctrl+p` and `ctrl+t` are shortcuts that are already assigned to the browser in Linux and Windows.

Note: I'm away from home for the week, so I cannot test this shortcut configuration on a Mac. From memory, I'd say there's no collision with something Mac specific.