### PR TITLE
Fix list manipulation bug

### DIFF
--- a/src/lib/export_org.js
+++ b/src/lib/export_org.js
@@ -176,11 +176,11 @@ export const attributedStringToRawText = parts => {
     return '';
   }
 
-  const prevPartTypes = parts.map(part => part.get('type')).unshift(null);
+  const prevParts = parts.unshift(null);
 
   return parts
-    .zip(prevPartTypes)
-    .map(([part, prevPartType]) => {
+    .zip(prevParts)
+    .map(([part, prevPart]) => {
       let text = '';
       switch (part.get('type')) {
         case 'text':
@@ -210,7 +210,18 @@ export const attributedStringToRawText = parts => {
           );
       }
 
-      const optionalNewlinePrefix = ['list', 'table'].includes(prevPartType) ? '\n' : '';
+      let optionalNewlinePrefix = '';
+      if (!!prevPart) {
+        if (['list', 'table'].includes(prevPart.get('type'))) {
+          optionalNewlinePrefix = '\n';
+        } else if (
+          part.get('type') === 'list' &&
+          prevPart.get('type') === 'text' &&
+          !prevPart.get('contents').endsWith('\n')
+        ) {
+          optionalNewlinePrefix = '\n';
+        }
+      }
       return optionalNewlinePrefix + text;
     })
     .join('');

--- a/src/lib/org_utils.js
+++ b/src/lib/org_utils.js
@@ -598,13 +598,15 @@ export const updateListContainingListItemId = (headers, listItemId, updaterCallb
 };
 
 export const updateContentsWithListItemAddition = (parts, listItem, listPart = null) => {
-  if (parts.size === 0) {
+  if ((parts.size === 0) || (parts.last().get('type') !== 'list')) {
+    const insertIdx = parts.size;
     if (!!listPart) {
-      parts = parts.insert(0, newListPartLikePart(listPart));
+      parts = parts.insert(insertIdx, newListPartLikePart(listPart));
     } else {
-      parts = parts.insert(0, newListPart());
+      parts = parts.insert(insertIdx, newListPart());
     }
   }
+
   return parts.map(part => {
     switch (part.get('type')) {
       case 'list':


### PR DESCRIPTION
This is bug fix of #142.

Intention of modification of src/lib/export_org.js is as below.
Without this change, move "2. test item 2" to right.
> 1. test item 1
>     xxx
> 2. test item 2  

And then, the text is saved as below.

> 1. test item 1
>     xxx1. test item 2

If there are any concerns, please let me know.